### PR TITLE
Fix object setValue

### DIFF
--- a/src/resources/elements/objectfield.js
+++ b/src/resources/elements/objectfield.js
@@ -61,7 +61,7 @@ export class Objectfield extends Parentfield {
     for (const [key, field] of Object.entries(value)) {
       if (this._children.hasOwnProperty(key)) {
         this._children[key].setValue(field);
-      } else if (this.legendChildren.hasOwnProperty(key)) {
+      } else if (this.legendChildren && this.legendChildren.hasOwnProperty(key)) {
         this.legendChildren[key].setValue(field);
       }
     }


### PR DESCRIPTION
When Objectfield#setValue() tries to set the value of a non-existent child and the objectfield has no legend, a ReferenceError is thrown. This pull request adds a check that legendChildren is not undefined and thus removes the possibility for an error.