### PR TITLE
Fix array child deletion

### DIFF
--- a/src/resources/elements/abstract/field.js
+++ b/src/resources/elements/abstract/field.js
@@ -219,7 +219,7 @@ export class Field {
    */
   delete() {
     if (this.parent) {
-      this.parent.deleteChild(this.index || this.id);
+      this.parent.deleteChild(typeof this.index === 'number' ? this.index : this.id);
     }
   }
 

--- a/src/resources/elements/abstract/field.js
+++ b/src/resources/elements/abstract/field.js
@@ -242,12 +242,16 @@ export class Field {
   /**
    * Clone this field.
    *
+   * @param {Field} parent The new parent of this field.
    * @return {Field} A deep clone of this field.
    */
-  clone() {
+  clone(parent) {
     const ExtendedClass = Object.getPrototypeOf(this).constructor;
     const clone = new ExtendedClass();
     clone.init(this.id, this);
+    if (parent) {
+      clone.parent = parent;
+    }
     return clone;
   }
 }

--- a/src/resources/elements/arrayfield.js
+++ b/src/resources/elements/arrayfield.js
@@ -115,10 +115,9 @@ export class Arrayfield extends Parentfield {
       return;
     }
 
-    const field = this.item.clone();
+    const field = this.item.clone(this);
     field.index = this._children.length;
     field.id = `${this.item.id}-${field.index}`;
-    field.parent = this;
     if (this.addIndexToChildLabel) {
       field.labelFormat = `${field.labelFormat} #$index`;
     }
@@ -148,9 +147,12 @@ export class Arrayfield extends Parentfield {
   }
 
   /** @inheritdoc */
-  clone() {
+  clone(parent) {
     const clone = new Arrayfield();
     clone.init(this.id, this);
+    if (parent) {
+      clone.parent = parent;
+    }
     if (this.item instanceof Field) {
       clone.item = this.item.clone();
     }

--- a/src/resources/elements/arrayfield.js
+++ b/src/resources/elements/arrayfield.js
@@ -118,6 +118,7 @@ export class Arrayfield extends Parentfield {
     const field = this.item.clone();
     field.index = this._children.length;
     field.id = `${this.item.id}-${field.index}`;
+    field.parent = this;
     if (this.addIndexToChildLabel) {
       field.labelFormat = `${field.labelFormat} #$index`;
     }

--- a/src/resources/elements/lazylinkfield.js
+++ b/src/resources/elements/lazylinkfield.js
@@ -24,8 +24,7 @@ export class LazyLinkfield extends Field {
    * This doesn't return anything, since it just sets the {@link #child} field.
    */
   createChild() {
-    this.child = this.resolveRef(this.target).clone();
-    this.child.parent = this;
+    this.child = this.resolveRef(this.target).clone(this);
     for (const [field, value] of Object.entries(this.overrides)) {
       let target;
       let fieldPath;

--- a/src/resources/elements/objectfield.js
+++ b/src/resources/elements/objectfield.js
@@ -76,17 +76,17 @@ export class Objectfield extends Parentfield {
   }
 
   /** @inheritdoc */
-  clone() {
+  clone(parent) {
     const clone = new Objectfield();
     const clonedChildren = {};
     for (const [key, field] of Object.entries(this._children)) {
-      clonedChildren[key] = field.clone();
+      clonedChildren[key] = field.clone(clone);
       clonedChildren[key].parent = clone;
     }
     const clonedLegendChildren = {};
     if (this.legendChildren) {
       for (const [key, field] of Object.entries(this.legendChildren)) {
-        clonedLegendChildren[key] = field.clone();
+        clonedLegendChildren[key] = field.clone(clone);
         clonedLegendChildren[key].parent = clone;
       }
     }
@@ -94,7 +94,7 @@ export class Objectfield extends Parentfield {
       label: this._label,
       columns: this.columns,
       collapsed: this.collapsed,
-      parent: this.parent,
+      parent: parent || this.parent,
       index: this.index,
       children: clonedChildren,
       legendChildren: clonedLegendChildren


### PR DESCRIPTION
Fixes #80 

The reason for #80 was that the parent of the cloned child was not set correctly when the form has many levels of nesting containing multiple array and other fields.

## Changes
* Add parent parameter to clone functions
* Give parent parameter in relevant places
* Ensure `field.delete()` gives the correct ID to `parent.deleteChild()`