### PR TITLE
Add YAML support and fix IE support for downloads

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,6 +11,7 @@
   "plugins": [
     "syntax-flow",
     "transform-decorators-legacy",
-    "transform-flow-strip-types"
+    "transform-flow-strip-types",
+    "transform-es2017-object-entries"
   ]
 }

--- a/aurelia_project/aurelia.json
+++ b/aurelia_project/aurelia.json
@@ -112,6 +112,11 @@
           "aurelia-templating-binding",
           "text",
           {
+            "name": "yamljs",
+            "path": "../node_modules/yamljs",
+            "main": "lib/Yaml"
+          },
+          {
             "name": "aurelia-templating-resources",
             "path": "../node_modules/aurelia-templating-resources/dist/amd",
             "main": "aurelia-templating-resources"

--- a/aurelia_project/aurelia.json
+++ b/aurelia_project/aurelia.json
@@ -91,6 +91,12 @@
           "node_modules/requirejs/require.js"
         ],
         "dependencies": [
+          {
+            "name": "babel-polyfill",
+            "main": "dist/polyfill.js",
+            "path": "../node_modules/babel-polyfill",
+            "resources": []
+          },
           "aurelia-binding",
           "aurelia-bootstrapper",
           "aurelia-dependency-injection",

--- a/aurelia_project/aurelia.json
+++ b/aurelia_project/aurelia.json
@@ -13,7 +13,9 @@
     "fileExtension": ".js",
     "options": {
       "plugins": [
-        "transform-es2015-modules-amd"
+        "transform-es2015-modules-amd",
+        "transform-decorators-legacy",
+        "transform-es2017-object-entries"
       ]
     },
     "source": "src/**/*.js"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "aurelia-bootstrapper": "^1.0.0",
     "bluebird": "^3.4.1",
     "requirejs": "^2.3.2",
-    "text": "github:requirejs/text#latest"
+    "text": "github:requirejs/text#latest",
+    "yamljs": "^0.2.10"
   },
   "peerDependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-plugin-transform-es2015-modules-amd": "^6.8.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.10.3",
     "babel-plugin-transform-flow-strip-types": "^6.8.0",
+    "babel-plugin-transform-es2017-object-entries": "0.0.4",
     "babel-preset-es2015": "^6.13.2",
     "babel-preset-stage-1": "^6.5.0",
     "babel-polyfill": "^6.9.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "aurelia-animator-css": "^1.0.0",
     "aurelia-bootstrapper": "^1.0.0",
+    "babel-polyfill": "^6.23.0",
     "bluebird": "^3.4.1",
     "requirejs": "^2.3.2",
     "text": "github:requirejs/text#latest",

--- a/src/app.html
+++ b/src/app.html
@@ -8,8 +8,12 @@
     <a href="#/tags">Tags</a>
     <a href="#/paths">Paths</a>
     <a href="#/types">Types</a>
-    <a href="javascript:void(0)" click.delegate="download('json')">Download (JSON)</a>
-    <a href="javascript:void(0)" click.delegate="download('yaml')">Download (YAML)</a>
+    <a href="javascript:void(0)" click.delegate="download('json')">
+      Download (JSON)
+    </a>
+    <a href="javascript:void(0)" click.delegate="download('yaml')">
+      Download (YAML)
+    </a>
   </div>
 
   <a href="https://github.com/apinf/open-api-designer"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>

--- a/src/app.html
+++ b/src/app.html
@@ -8,7 +8,8 @@
     <a href="#/tags">Tags</a>
     <a href="#/paths">Paths</a>
     <a href="#/types">Types</a>
-    <a href="javascript:void(0)" click.delegate="download('json')">Download</a>
+    <a href="javascript:void(0)" click.delegate="download('json')">Download (JSON)</a>
+    <a href="javascript:void(0)" click.delegate="download('yaml')">Download (YAML)</a>
   </div>
 
   <a href="https://github.com/apinf/open-api-designer"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>

--- a/src/app.js
+++ b/src/app.js
@@ -40,7 +40,7 @@ export class App {
     // the element to download the data.
     const blob = new Blob([data], {type: 'text/json'});
     if (window.navigator.msSaveOrOpenBlob) {
-      window.navigator.msSaveBlob(blob, filename);
+      window.navigator.msSaveBlob(blob, `swagger.${type}`);
     } else {
       const downloadLink = document.createElement('a');
       downloadLink.href = window.URL.createObjectURL(blob);

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,6 @@
 import {parseJSON} from './resources/jsonparser';
 import {schema} from './schemas/index';
+import YAML from 'yamljs';
 
 export class App {
   constructor() {
@@ -29,23 +30,29 @@ export class App {
     let data;
     if (type === 'json') {
       data = this.json;
-    } else if (type === 'yml') {
-      data = 'yaml-support-implemented: false';
+    } else if (type === 'yaml') {
+      data = this.yaml;
     } else {
       return;
     }
 
     // Add an anchor element that has the data as the href attribute, then click
     // the element to download the data.
-    const str = `data:text/json;charset=utf-8,${data}`;
-    const downloadLink = document.createElement('a');
-    downloadLink.setAttribute('href', str);
-    downloadLink.setAttribute('download', `swagger.${type}`);
-    downloadLink.innerHTML = 'Download Open API specification file';
-    downloadLink.hidden = true;
-    document.body.appendChild(downloadLink);
-    downloadLink.click();
-    downloadLink.remove();
+    const blob = new Blob([data], {type: 'text/json'});
+    if (window.navigator.msSaveOrOpenBlob) {
+      window.navigator.msSaveBlob(blob, filename);
+    } else {
+      const downloadLink = document.createElement('a');
+      downloadLink.href = window.URL.createObjectURL(blob);
+      downloadLink.download = `swagger.${type}`;
+      document.body.appendChild(downloadLink);
+      downloadLink.click();
+      document.body.removeChild(downloadLink);
+    }
+  }
+
+  get yaml() {
+    return YAML.stringify(this.forms.getValue(), 10, 2);
   }
 
   get json() {

--- a/src/main.js
+++ b/src/main.js
@@ -1,11 +1,5 @@
+import 'babel-polyfill';
 import environment from './environment';
-
-//Configure Bluebird Promises.
-Promise.config({
-  warnings: {
-    wForgottenReturn: false
-  }
-});
 
 export function configure(aurelia) {
   aurelia.use


### PR DESCRIPTION
Closes #63

This pull request adds support for downloading the data as a YAML file and should also fix downloading from IE.

@Nazarah Could you test this in IE? There's a demo of this branch available at https://oai.maunium.net/feature/improve-downloads/ If it doesn't work, please send the error information from the browser console.