### PR TITLE
Flatten Typefield children if they have their own children

### DIFF
--- a/src/resources/elements/arrayfield.html
+++ b/src/resources/elements/arrayfield.html
@@ -1,5 +1,5 @@
 <template>
-  <div class="array field c${columns} columns" if.bind="display">
+  <div class="array field has-children c${columns} columns" if.bind="display">
     <h3 click.delegate="toggleCollapse()" class="title">
       ${label}
       <tooltip if.bind="helpText" text.bind="helpText">

--- a/src/resources/elements/objectfield.html
+++ b/src/resources/elements/objectfield.html
@@ -1,5 +1,5 @@
 <template>
-  <fieldset class="object field c${columns} columns" if.bind="display">
+  <fieldset class="object field has-children c${columns} columns" if.bind="display">
     <legend if.bind="hasLegend && !collapsed">
       <template repeat.for="childElem of iterableLegendChildren">
         <compose containerless view-model.bind="childElem"></compose>

--- a/src/resources/elements/typefield.html
+++ b/src/resources/elements/typefield.html
@@ -1,5 +1,5 @@
 <template>
-  <fieldset class="type field c${columns} columns" if.bind="display">
+  <fieldset class="type field has-children c${columns} columns" if.bind="display">
     <legend>
       <select value.two-way="selectedType">
         <option repeat.for="type of possibleTypes">${type}</option>

--- a/src/style/_form.scss
+++ b/src/style/_form.scss
@@ -119,7 +119,7 @@
     }
   }
 
-  &.object, &.array, &.type {
+  &.has-children {
     margin: .25rem;
     padding: .25rem;
 
@@ -154,23 +154,31 @@
     }
   }
 
-  &.type > legend {
-    select + input {
-      margin-left: .5rem;
-      padding: .2rem;
+  &.type {
+    > legend {
+      select + input {
+        margin-left: .5rem;
+        padding: .2rem;
 
-      border: .0625rem solid $border-color;
-      border-radius: .25rem;
+        border: .0625rem solid $border-color;
+        border-radius: .25rem;
 
-      &:hover {
-        border-bottom: .0625rem solid $main-color;
+        &:hover {
+          border-bottom: .0625rem solid $main-color;
+        }
+
+        &:focus {
+          margin-bottom: 0;
+
+          border-bottom: .125rem solid $main-color;
+        }
       }
+    }
 
-      &:focus {
-        margin-bottom: 0;
-
-        border-bottom: .125rem solid $main-color;
-      }
+    > .has-children {
+      border: none;
+      margin: 0;
+      padding: 0;
     }
   }
 


### PR DESCRIPTION
Fixes #123 

This pull request adds the class `has-children` for fields that have children (`Typefield`, `Objectfield` and `Arrayfield`) and changes the `Typefield` styles so if the child has the class `has-children`, the border, padding and margin of the child will be removed.

### Before
![before](https://img.mau.lu/OjQed.png)
### After
![after](https://img.mau.lu/RRvFW.png)