### PR TITLE
Allow setting which field to use as the value for map entries

### DIFF
--- a/src/resources/elements/arrayfield.js
+++ b/src/resources/elements/arrayfield.js
@@ -18,6 +18,12 @@ export class Arrayfield extends Parentfield {
    */
   keyField = '_key';
   /**
+   * The field that is used as the value if {@link #format} is {@linkplain map}
+   * This field is optional. By default, the whole value will be used as-is.
+   * @type {String}
+   */
+  valueField = undefined;
+  /**
    * Whether or not to add {@linkplain #<index>} to the end of the labels of
    * children.
    * @type {Boolean}
@@ -34,17 +40,29 @@ export class Arrayfield extends Parentfield {
 
   /**
    * @inheritdoc
-   * @param {Field}   [args.item]      The base object that is cloned to create
-   *                                   new children.
-   * @param {String}  [args.keyField]  The field that is used as the key if
-   *                                   {@link #format} is {@linkplain map}
-   * @param {Boolean} [args.collapsed] Whether or not the UI element should be
-   *                                   collapsed.
+   * @param {Field}   [args.item]       The base object that is cloned to create
+   *                                    new children.
+   * @param {String}  [args.keyField]   The field that is used as the key if
+   *                                    {@link #format} is {@linkplain map}
+   * @param {String}  [args.valueField] The field that is used as the value if
+   *                                    {@link #format} is {@linkplain map}.
+   *                                    This field is optional. By default, the
+   *                                    whole value will be used as-is.
+   * @param {Boolean} [args.collapsed]  Whether or not the UI element should be
+   *                                    collapsed.
    */
   init(id = '', args = {}) {
-    args = Object.assign({format: 'array', keyField: '_key', addIndexToChildLabel: true, collapseManagement: false, collapsed: false}, args);
+    args = Object.assign({
+      format: 'array',
+      keyField: '_key',
+      valueField: undefined,
+      addIndexToChildLabel: true,
+      collapseManagement: false,
+      collapsed: false
+    }, args);
     this.item = args.item;
     this.keyField = args.keyField;
+    this.valueField = args.valueField;
     this.addIndexToChildLabel = args.addIndexToChildLabel;
     this.collapseManagement = args.collapseManagement;
     this.collapsed = args.collapsed;
@@ -66,8 +84,12 @@ export class Arrayfield extends Parentfield {
         }
         const data = item.getValue();
         const key = data[this.keyField];
-        delete data[this.keyField];
-        value[key] = data;
+        if (this.valueField) {
+          value[key] = data[this.valueField];
+        } else {
+          delete data[this.keyField];
+          value[key] = data;
+        }
       }
     } else if (this.format === 'array') {
       value = [];


### PR DESCRIPTION
This pull request adds a `valueField` field to `Arrayfield`s which allows map-type arrays to use the value of a specific field as the value of map entries rather than using the whole object as the value.