### PR TITLE
Fix security definitions form

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -17,7 +17,7 @@
     <a class="nav-link" id="nav-about" href="#/about">About</a>
     <a class="nav-link open" id="nav-header" href="#/header">Header</a>
     <a class="nav-link" id="nav-mime" href="#/mime">MIME types</a>
-    <a class="nav-link" id="nav-security" href="#/security">Security</a>
+    <a class="nav-link" id="nav-security-definitions" href="#/securityDefinitions">Security</a>
     <a class="nav-link" id="nav-tags" href="#/tags">Tags</a>
     <a class="nav-link" id="nav-paths" href="#/paths">Paths</a>
     <a class="nav-link" id="nav-types" href="#/types">Types</a>

--- a/src/app.html
+++ b/src/app.html
@@ -17,7 +17,7 @@
     <a class="nav-link" id="nav-about" href="#/about">About</a>
     <a class="nav-link open" id="nav-header" href="#/header">Header</a>
     <a class="nav-link" id="nav-mime" href="#/mime">MIME types</a>
-    <a class="nav-link" id="nav-security-definitions" href="#/securityDefinitions">Security</a>
+    <a class="nav-link" id="nav-security" href="#/global-security">Security</a>
     <a class="nav-link" id="nav-tags" href="#/tags">Tags</a>
     <a class="nav-link" id="nav-paths" href="#/paths">Paths</a>
     <a class="nav-link" id="nav-types" href="#/types">Types</a>

--- a/src/schemas/index.js
+++ b/src/schemas/index.js
@@ -1,6 +1,6 @@
 import {header} from './header';
 import {mime} from './mime';
-import {securityDefinitions} from './security';
+import {security} from './security';
 import {tags} from './tags';
 import {paths} from './paths';
 import {types} from './types';
@@ -15,7 +15,8 @@ export const fieldsToShow = {
     'schemes'
   ],
   'types': ['definitions'],
-  'mime': ['consumes', 'produces']
+  'mime': ['consumes', 'produces'],
+  'global-security': ['security', 'securityDefinitions']
 };
 
 export const schema = {
@@ -23,10 +24,18 @@ export const schema = {
   'children': {
     header,
     mime,
-    securityDefinitions,
+    'global-security': security,
     tags,
     paths,
     types,
+    'security': {
+      'type': 'link',
+      'target': '/global-security/requirements'
+    },
+    'securityDefinitions': {
+      'type': 'link',
+      'target': '/global-security/definitions'
+    },
     'definitions': {
       'type': 'link',
       'target': '/types'

--- a/src/schemas/index.js
+++ b/src/schemas/index.js
@@ -1,6 +1,6 @@
 import {header} from './header';
 import {mime} from './mime';
-import {security} from './security';
+import {securityDefinitions} from './security';
 import {tags} from './tags';
 import {paths} from './paths';
 import {types} from './types';
@@ -23,7 +23,7 @@ export const schema = {
   'children': {
     header,
     mime,
-    security,
+    securityDefinitions,
     tags,
     paths,
     types,

--- a/src/schemas/security.js
+++ b/src/schemas/security.js
@@ -1,6 +1,7 @@
-export const security = {
+export const securityDefinitions = {
   'type': 'array',
   'format': 'map',
+  'label': 'Security Definitions',
   'keyField': 'key',
   'item': {
     'label': 'Security definition',
@@ -60,22 +61,24 @@ export const security = {
             'conditions': {
               '../flow': ['password', 'application', 'accessCode']
             }
-          }/*,
+          },
           'scopes': {
             'type': 'array',
             'format': 'map',
             'keyField': 'key',
+            'valueField': 'value',
             'item': {
               'type': 'object',
-              'keyField': 'key',
               'children': {
                 'key': {
                   'type': 'text'
                 },
-                'value':
+                'description': {
+                  'type': 'text'
+                }
               }
             }
-          }*/
+          }
         }
       }
     }

--- a/src/schemas/security.js
+++ b/src/schemas/security.js
@@ -1,7 +1,35 @@
-export const securityDefinitions = {
+const securityRequirements = {
   'type': 'array',
   'format': 'map',
-  'label': 'Security Definitions',
+  'keyField': 'name',
+  'valueField': 'scopes',
+  'label': 'Requirements',
+  'item': {
+    'label': 'Security Requirement',
+    'type': 'object',
+    'children': {
+      'name': {
+        'type': 'option',
+        'format': 'dropdown',
+        'dataSources': [{
+          'source': '/global-security/definitions',
+          'key': '#:key'
+        }]
+      },
+      'scopes': {
+        'type': 'array',
+        'item': {
+          'type': 'text'
+        }
+      }
+    }
+  }
+};
+
+const securityDefinitions = {
+  'type': 'array',
+  'format': 'map',
+  'label': 'Definitions',
   'keyField': 'key',
   'item': {
     'label': 'Security definition',
@@ -82,5 +110,14 @@ export const securityDefinitions = {
         }
       }
     }
+  }
+};
+
+export const security = {
+  'type': 'object',
+  'label': 'Security',
+  'children': {
+    definitions: securityDefinitions,
+    requirements: securityRequirements
   }
 };


### PR DESCRIPTION
This fixes the security definitions form by
1. Fixing the name in the output (from `security` to `securityDefinitions`)
2. Adding the missing `scopes` field when using OAuth 2

For the second fix to work properly (to get valid Swagger output), #125 has to be merged too.