### PR TITLE
Allow hiding empty values automatically

### DIFF
--- a/src/resources/elements/abstract/field.js
+++ b/src/resources/elements/abstract/field.js
@@ -55,6 +55,12 @@ export class Field {
    */
   showValueInParent = true
   /**
+   * Whether or not the value of this field should be hidden from the output
+   * when its empty.
+   * @type {Boolean}
+   */
+  hideValueIfEmpty = false
+  /**
    * Whether or not this field has the field {@link #collapsed} and the method
    * {@link #toggleCollapse()}
    *
@@ -78,6 +84,9 @@ export class Field {
    * @param  {Boolean} [args.showValueInParent] Whether or not the parent should
    *                                            include the value of this field
    *                                            in its value.
+   * @param  {Boolean} [args.hideValueIfEmpty]  Whether or not the value of this
+   *                                            field should be hidden from the
+   *                                            output when its empty.
    * @return {Field}                    This field.
    */
   init(id, args = {}) {
@@ -87,7 +96,8 @@ export class Field {
       format: '',
       helpText: '',
       conditions: {},
-      showValueInParent: true
+      showValueInParent: true,
+      hideValueIfEmpty: false
     }, args);
     this.id = id;
     this.format = args.format;
@@ -98,7 +108,12 @@ export class Field {
     this.index = args.index;
     this.parent = args.parent;
     this.showValueInParent = args.showValueInParent;
+    this.hideValueIfEmpty = args.hideValueIfEmpty;
     return this;
+  }
+
+  isEmpty() {
+    return false;
   }
 
   get display() {

--- a/src/resources/elements/abstract/field.js
+++ b/src/resources/elements/abstract/field.js
@@ -112,6 +112,10 @@ export class Field {
     return this;
   }
 
+  /**
+   * Check if this field is empty. By default, this returns false, but all field
+   * implementations should override this.
+   */
   isEmpty() {
     return false;
   }

--- a/src/resources/elements/abstract/field.js
+++ b/src/resources/elements/abstract/field.js
@@ -56,7 +56,7 @@ export class Field {
   showValueInParent = true
   /**
    * Whether or not the value of this field should be hidden from the output
-   * when its empty.
+   * when it's empty.
    * @type {Boolean}
    */
   hideValueIfEmpty = false

--- a/src/resources/elements/arrayfield.js
+++ b/src/resources/elements/arrayfield.js
@@ -51,9 +51,14 @@ export class Arrayfield extends Parentfield {
     return super.init(id, args);
   }
 
+  /**
+   * Check if this array is empty. If all children are empty, then this field is
+   * also considered to be empty.
+   */
   isEmpty() {
     for (const child of this._children) {
       if (!child.isEmpty()) {
+        // This field is not empty if any of the children is not empty.
         return false;
       }
     }

--- a/src/resources/elements/arrayfield.js
+++ b/src/resources/elements/arrayfield.js
@@ -51,6 +51,15 @@ export class Arrayfield extends Parentfield {
     return super.init(id, args);
   }
 
+  isEmpty() {
+    for (const child of this._children) {
+      if (!child.isEmpty()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   /**
    * @inheritdoc
    * @return {Object[]|Object} The values of the children of this array in the
@@ -63,6 +72,8 @@ export class Arrayfield extends Parentfield {
       for (const item of this._children) {
         if (!item.showValueInParent || !item.display) {
           continue;
+        } else if (item.isEmpty() && item.hideValueIfEmpty) {
+          continue;
         }
         const data = item.getValue();
         const key = data[this.keyField];
@@ -73,6 +84,8 @@ export class Arrayfield extends Parentfield {
       value = [];
       for (const [index, item] of Object.entries(this._children)) {
         if (!item.showValueInParent || !item.display) {
+          continue;
+        } else if (item.isEmpty() && item.hideValueIfEmpty) {
           continue;
         }
         value[index] = item.getValue();

--- a/src/resources/elements/lazylinkfield.js
+++ b/src/resources/elements/lazylinkfield.js
@@ -18,6 +18,9 @@ export class LazyLinkfield extends Field {
     return super.init(id, args);
   }
 
+  /**
+   * Check if this link doesn't currently have a child or if the child is empty.
+   */
   isEmpty() {
     if (!this.child) {
       return true;

--- a/src/resources/elements/lazylinkfield.js
+++ b/src/resources/elements/lazylinkfield.js
@@ -18,6 +18,13 @@ export class LazyLinkfield extends Field {
     return super.init(id, args);
   }
 
+  isEmpty() {
+    if (!this.child) {
+      return true;
+    }
+    return this.child.isEmpty();
+  }
+
   /**
    * Create the child of this field. Basically copy the target, set the parent
    * and apply field overrides.

--- a/src/resources/elements/linkfield.js
+++ b/src/resources/elements/linkfield.js
@@ -19,6 +19,10 @@ export class Linkfield extends Field {
     return super.init(id, args);
   }
 
+  /**
+   * Check if this link doesn't currently have a resolvable target or if the
+   * target is empty.
+   */
   isEmpty() {
     const field = this.resolveTarget();
     if (!field) {

--- a/src/resources/elements/linkfield.js
+++ b/src/resources/elements/linkfield.js
@@ -19,6 +19,14 @@ export class Linkfield extends Field {
     return super.init(id, args);
   }
 
+  isEmpty() {
+    const field = this.resolveTarget();
+    if (!field) {
+      return true;
+    }
+    return field.isEmpty();
+  }
+
   /**
    * Resolve the path to the target.
    * @return {Field} The target field, or {@linkplain undefined} if the target

--- a/src/resources/elements/objectfield.js
+++ b/src/resources/elements/objectfield.js
@@ -23,6 +23,10 @@ export class Objectfield extends Parentfield {
     return super.init(id, args);
   }
 
+  /**
+   * Check if this object is empty. If all children are empty, then this field
+   * is also considered to be empty.
+   */
   isEmpty() {
     for (const child of Object.values(this.allChildren)) {
       if (!child.isEmpty()) {

--- a/src/resources/elements/objectfield.js
+++ b/src/resources/elements/objectfield.js
@@ -23,6 +23,15 @@ export class Objectfield extends Parentfield {
     return super.init(id, args);
   }
 
+  isEmpty() {
+    for (const child of Object.values(this.allChildren)) {
+      if (!child.isEmpty()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   /**
    * @inheritdoc
    * @return {Object} The values of the children in an object. The keys are the
@@ -32,6 +41,8 @@ export class Objectfield extends Parentfield {
     const value = {};
     for (const [key, field] of Object.entries(this.allChildren)) {
       if (!field || !field.showValueInParent || !field.display) {
+        continue;
+      } else if (field.isEmpty() && field.hideValueIfEmpty) {
         continue;
       }
       value[key] = field.getValue();
@@ -96,6 +107,7 @@ export class Objectfield extends Parentfield {
       collapsed: this.collapsed,
       parent: parent || this.parent,
       index: this.index,
+      hideValueIfEmpty: this.hideValueIfEmpty,
       children: clonedChildren,
       legendChildren: clonedLegendChildren
     });

--- a/src/resources/elements/textfield.js
+++ b/src/resources/elements/textfield.js
@@ -29,6 +29,9 @@ export class Textfield extends Field {
     return super.init(id, args);
   }
 
+  /**
+   * Check if the text input field is empty.
+   */
   isEmpty() {
     return this.value.length === 0;
   }

--- a/src/resources/elements/textfield.js
+++ b/src/resources/elements/textfield.js
@@ -29,6 +29,10 @@ export class Textfield extends Field {
     return super.init(id, args);
   }
 
+  isEmpty() {
+    return this.value.length === 0;
+  }
+
   /**
    * @inheritdoc
    * @return {String} The text in the input field.

--- a/src/resources/elements/typefield.js
+++ b/src/resources/elements/typefield.js
@@ -71,6 +71,13 @@ export class Typefield extends Field {
     return super.init(id, args);
   }
 
+  isEmpty() {
+    if (!this.child) {
+      return true;
+    }
+    return this.child.isEmpty();
+  }
+
   /**
    * Called by Aurelia when the selected type changes (e.g. from the dropdown)
    * @param {String} newType The new type.

--- a/src/resources/elements/typefield.js
+++ b/src/resources/elements/typefield.js
@@ -71,6 +71,9 @@ export class Typefield extends Field {
     return super.init(id, args);
   }
 
+  /**
+   * Check if this field doesn't currently have a child or if the child is empty.
+   */
   isEmpty() {
     if (!this.child) {
       return true;


### PR DESCRIPTION
This pull request adds the field `hideValueIfEmpty`. If set to `true`, the value of the field will not be visible in the values of parent `Arrayfield`s and `Objectfield`s.

This is going to be used for methods in the Paths form (to hide the methods from output if they aren't used)