### PR TITLE
Add tabbed view for Objectfields

### DIFF
--- a/src/resources/elements/objectfield-tabbed.html
+++ b/src/resources/elements/objectfield-tabbed.html
@@ -11,9 +11,9 @@
         <img src="res/info.svg" alt="Info"/>
       </tooltip>
     </h3>
-    <div class="tabs" if.bind="!collapsed">
+    <div class="tabs" if.bind="!collapsed" ref="tabs">
       <template repeat.for="childElem of iterableChildren">
-        <a class="tab-link" if.bind="childElem.display" click.delegate="switchTab(childElem)">
+        <a class="tab-link" id="tab-${childElem.path}" if.bind="childElem.display" click.delegate="switchTab(childElem)">
           ${childElem.label}
         </a>
       </template>

--- a/src/resources/elements/objectfield-tabbed.html
+++ b/src/resources/elements/objectfield-tabbed.html
@@ -1,0 +1,23 @@
+<template>
+  <fieldset class="tabbed object field has-children c${columns} columns" if.bind="display">
+    <legend if.bind="hasLegend && !collapsed">
+      <template repeat.for="childElem of iterableLegendChildren">
+        <compose containerless view-model.bind="childElem"></compose>
+      </template>
+    </legend>
+    <h3 click.delegate="toggleCollapse()" class="title">
+      ${label}
+      <tooltip if.bind="helpText" text.bind="helpText">
+        <img src="res/info.svg" alt="Info"/>
+      </tooltip>
+    </h3>
+    <div class="tabs" if.bind="!collapsed">
+      <template repeat.for="childElem of iterableChildren">
+        <a class="tab-link" if.bind="childElem.display" click.delegate="switchTab(childElem)">
+          ${childElem.label}
+        </a>
+      </template>
+    </div>
+    <compose containerless if.bind="!collapsed" view-model.bind="activeChild"></compose>
+  </fieldset>
+</template>

--- a/src/resources/elements/objectfield.js
+++ b/src/resources/elements/objectfield.js
@@ -13,11 +13,20 @@ export class Objectfield extends Parentfield {
    * The fields to display in the legend slot of the form.
    */
   legendChildren = undefined;
+  /**
+   * The child that is currently open in the tabbed view.
+   * @type {Field}
+   */
+  activeChild = undefined;
 
   /** @inheritdoc */
   init(id = '', args = {}) {
     args = Object.assign({children: {}, collapsed: false, legendChildren: undefined}, args);
     this._children = args.children;
+    const iterableChildren = this.iterableChildren;
+    if (iterableChildren.length > 0) {
+      this.switchTab(this.iterableChildren[0]);
+    }
     this.collapsed = args.collapsed;
     this.legendChildren = args.legendChildren;
     return super.init(id, args);
@@ -75,6 +84,10 @@ export class Objectfield extends Parentfield {
     this._children[child.id] = child;
   }
 
+  switchTab(toChild) {
+    this.activeChild = toChild;
+  }
+
   /** @inheritdoc */
   clone(parent) {
     const clone = new Objectfield();
@@ -91,6 +104,7 @@ export class Objectfield extends Parentfield {
       }
     }
     clone.init(this.id, {
+      format: this.format,
       label: this._label,
       columns: this.columns,
       collapsed: this.collapsed,
@@ -115,5 +129,17 @@ export class Objectfield extends Parentfield {
       }
     }
     return undefined;
+  }
+
+  /**
+   * @return {String} The name of the HTML file that displays the object with
+   *                  the format specified in {@link #format}.
+   * @private
+   */
+  getViewStrategy() {
+    if (this.format === 'tabs') {
+      return 'resources/elements/objectfield-tabbed.html';
+    }
+    return 'resources/elements/objectfield.html';
   }
 }

--- a/src/resources/elements/objectfield.js
+++ b/src/resources/elements/objectfield.js
@@ -23,13 +23,20 @@ export class Objectfield extends Parentfield {
   init(id = '', args = {}) {
     args = Object.assign({children: {}, collapsed: false, legendChildren: undefined}, args);
     this._children = args.children;
-    const iterableChildren = this.iterableChildren;
-    if (iterableChildren.length > 0) {
-      this.switchTab(this.iterableChildren[0]);
-    }
     this.collapsed = args.collapsed;
     this.legendChildren = args.legendChildren;
     return super.init(id, args);
+  }
+
+  attached() {
+    // Is this a tabbed objectfield that has children?
+    if (this.iterableChildren.length > 0 && this.format === 'tabs') {
+      // Are there no active tabs?
+      if ($(this.tabs).find('.tab-link.open').length === 0) {
+        // Then activate the first tab.
+        this.switchTab(this.iterableChildren[0]);
+      }
+    }
   }
 
   /**
@@ -86,6 +93,9 @@ export class Objectfield extends Parentfield {
 
   switchTab(toChild) {
     this.activeChild = toChild;
+    const tabElem = $(`#tab-${toChild.path.replace(/\./g, '\\.')}`);
+    tabElem.parent().find('.tab-link.open').removeClass('open');
+    tabElem.addClass('open');
   }
 
   /** @inheritdoc */

--- a/src/style/_form.scss
+++ b/src/style/_form.scss
@@ -154,6 +154,47 @@
     }
   }
 
+  &.tabbed.object {
+    > .tabs {
+      padding: .5rem 1rem;
+
+      border-bottom: 1px solid lightgray;
+      background-color: white;
+      > .tab-link {
+        display: inline;
+
+        box-sizing: border-box;
+        padding: .5rem 1rem;
+
+        text-decoration: none !important;
+
+        color: #337ab7 !important;
+        border-radius: .25rem .25rem 0 0;
+
+        &:hover {
+          background-color: lighten(lightgray, 7%);
+        }
+
+        &.open {
+          color: black !important;
+          border: 1px solid lightgray;
+          border-bottom: 1px solid white;
+
+          &:focus {
+            outline: 1px dotted lightgray;
+          }
+        }
+      }
+    }
+
+    > .has-children {
+      margin: .25rem 0 0;
+      padding: 0;
+
+      border: none;
+    }
+  }
+
   &.type {
     > legend {
       select + input {
@@ -176,9 +217,10 @@
     }
 
     > .has-children {
-      border: none;
       margin: 0;
       padding: 0;
+
+      border: none;
     }
   }
 


### PR DESCRIPTION
This pull request adds a tabbed view for `Objectfield`s. This allows us to display things like the 7 HTTP methods in Paths in a nicer way.

The latest commit requires PR #143, so that must be merged before this one to avoid broken commits.