### PR TITLE
Fix WebSocket scheme keys

### DIFF
--- a/src/schemas/header.js
+++ b/src/schemas/header.js
@@ -44,10 +44,10 @@ export const header = {
             'key': 'https',
             'label': 'HTTPS'
           }, {
-            'key': 'websocket',
+            'key': 'ws',
             'label': 'WebSocket'
           }, {
-            'key': 'websockets',
+            'key': 'wss',
             'label': 'Secure WebSocket'
           }]
         }

--- a/src/schemas/index.js
+++ b/src/schemas/index.js
@@ -11,7 +11,8 @@ export const fieldsToShow = {
     'contact',
     'license',
     'host',
-    'basePath'
+    'basePath',
+    'schemes'
   ],
   'types': ['definitions'],
   'mime': ['consumes', 'produces']


### PR DESCRIPTION
The keys were incorrectly set as `websocket` (for normal websocket) and `websockets` (for secure websocket) while they should be `ws` and `wss`. This pull request also makes the `schemes` array visible in the preview: a bug that was partly responsible for the incorrect keys.