### PR TITLE
Allow collapsing Typefields

### DIFF
--- a/src/resources/elements/typefield.html
+++ b/src/resources/elements/typefield.html
@@ -1,6 +1,6 @@
 <template>
   <fieldset class="type field has-children c${columns} columns" if.bind="display">
-    <legend>
+    <legend if.bind="!collapsed">
       <select value.two-way="selectedType">
         <option repeat.for="type of possibleTypes">${type}</option>
       </select>
@@ -12,6 +12,6 @@
         <img src="res/info.svg" alt="Info"/>
       </tooltip>
     </h3>
-    <compose containerless view-model.bind="child"></compose>
+    <compose if.bind="!collapsed" containerless view-model.bind="child"></compose>
   </fieldset>
 </template>

--- a/src/resources/elements/typefield.js
+++ b/src/resources/elements/typefield.js
@@ -56,6 +56,10 @@ export class Typefield extends Field {
   collapsed = false;
   isCollapsible = true;
 
+  /*
+   * Called by child fields when they are collapsed/uncollapsed.
+   * Unused in Typefields, currently only used in Arrayfields.
+   */
   childCollapseChanged(field, isNowCollapsed) {}
 
   toggleCollapse() {

--- a/src/resources/elements/typefield.js
+++ b/src/resources/elements/typefield.js
@@ -49,6 +49,25 @@ export class Typefield extends Field {
    * @type {Object}
    */
   types = {};
+  /**
+   * Whether or not the UI element should be collapsed (i.e. only show the title)
+   * @type {Boolean}
+   */
+  collapsed = false;
+  isCollapsible = true;
+
+  childCollapseChanged(field, isNowCollapsed) {}
+
+  toggleCollapse() {
+    this.setCollapsed(!this.collapsed);
+  }
+
+  setCollapsed(collapsed) {
+    this.collapsed = collapsed;
+    if (this.parent) {
+      this.parent.childCollapseChanged(this, this.collapsed);
+    }
+  }
 
   /** @inheritdoc */
   init(id = '', args = {}) {
@@ -58,6 +77,7 @@ export class Typefield extends Field {
       keyPlaceholder: 'Object key...',
       showType: true,
       copyValue: false,
+      collapsed: false,
       types: { 'null': { 'type': 'text' } }
     }, args);
     this.types = args.types;
@@ -66,6 +86,8 @@ export class Typefield extends Field {
     this.keyPlaceholder = args.keyPlaceholder;
     this.showType = args.showType;
     this.copyValue = args.copyValue;
+    this.collapsed = args.collapsed;
+    this.defaultType = args.defaultType;
     this.selectedType = args.defaultType || Object.keys(this.types)[0];
     this.selectedTypeChanged(this.selectedType);
     return super.init(id, args);


### PR DESCRIPTION
This pull request makes `Typefield`s collapsible in the same way `Arrayfield`s and `Objectfield`s can be collapsed.