### PR TITLE
Split up and document field label formatters

### DIFF
--- a/src/resources/elements/abstract/field.js
+++ b/src/resources/elements/abstract/field.js
@@ -144,6 +144,12 @@ export class Field {
 
     return label
         .replace(/\$index/g, this.index + 1)
+        // Match a form field reference optionally followed by a JS field or function.
+        //
+        // Examples:
+        //   #/reference/to/form/field:jsFieldName
+        //   #/another/reference:jsFunctionName()
+        //   #/third/reference/without/js/field
         .replace(/\${(.+?)(\:([a-zA-Z0-9]+(\(\))?))?}/g, (match, path, _, field) => {
           const elem = this.resolveRef(path);
           if (elem !== undefined) {

--- a/src/resources/elements/abstract/field.js
+++ b/src/resources/elements/abstract/field.js
@@ -156,7 +156,7 @@ export class Field {
       return label;
     }
 
-    return formatReferencePlusField(formatIndex(label));
+    return this.formatReferencePlusField(this.formatIndex(label));
   }
 
   /**

--- a/src/resources/elements/abstract/field.js
+++ b/src/resources/elements/abstract/field.js
@@ -144,13 +144,37 @@ export class Field {
 
     return label
         .replace(/\$index/g, this.index + 1)
-        .replace(/\${(.+?)}/g, (match, capture) => {
-          const elem = this.resolveRef(capture);
+        .replace(/\${(.+?)(\:([a-zA-Z0-9]+(\(\))?))?}/g, (match, path, _, field) => {
+          const elem = this.resolveRef(path);
           if (elem !== undefined) {
+            if (field !== undefined) {
+              return elem.getFieldValue(field);
+            }
+            // Field name not specified, return the value of the form field.
             return elem.getValue();
           }
+          // Form field not found.
           return '';
         });
+  }
+
+  /**
+   * Get the value of the given field or function.
+   * @param  {String} name The name of the field. If the field is a function that
+   *                       should be called, add {@linkplain ()} to the end.
+   * @return {[type]}      [description]
+   */
+  getFieldValue(name) {
+    if (name === undefined) {
+      return undefined;
+    }
+
+    if (name.endsWith('()')) {
+      // Field name specified with braces, so call the field as a function.
+      return this[name.substr(0, name.length - 2)]();
+    }
+    // Field name specified without braces, so just get the value of that field.
+    return this[name];
   }
 
   /**

--- a/src/resources/elements/abstract/field.js
+++ b/src/resources/elements/abstract/field.js
@@ -3,6 +3,20 @@
  */
 export class Field {
   /**
+   * Match a form field reference optionally followed by a JS field or function.
+   *
+   * Examples:
+   *   {@linkplain #/reference/to/form/field:jsFieldName}
+   *   {@linkplain #/another/reference:jsFunctionName()}
+   *   {@linkplain #/third/reference/without/js/field}
+  */
+  static MATCH_REFERENCE_PLUS_FIELD = /\${(.+?)(\:([a-zA-Z0-9]+(\(\))?))?}/g
+  /**
+   * Match the string {@linkplain $index}
+   * @type {String}
+   */
+  static MATCH_INDEX = /\$index/g
+  /**
    * The ID of the field. Not displayed to the user directly.
    * @type {String}
    */
@@ -143,14 +157,8 @@ export class Field {
     }
 
     return label
-        .replace(/\$index/g, this.index + 1)
-        // Match a form field reference optionally followed by a JS field or function.
-        //
-        // Examples:
-        //   #/reference/to/form/field:jsFieldName
-        //   #/another/reference:jsFunctionName()
-        //   #/third/reference/without/js/field
-        .replace(/\${(.+?)(\:([a-zA-Z0-9]+(\(\))?))?}/g, (match, path, _, field) => {
+        .replace(Field.MATCH_INDEX, this.index + 1)
+        .replace(Field.MATCH_REFERENCE_PLUS_FIELD, (match, path, _, field) => {
           const elem = this.resolveRef(path);
           if (elem !== undefined) {
             if (field !== undefined) {

--- a/src/resources/elements/abstract/field.js
+++ b/src/resources/elements/abstract/field.js
@@ -156,20 +156,37 @@ export class Field {
       return label;
     }
 
-    return label
-        .replace(Field.MATCH_INDEX, this.index + 1)
-        .replace(Field.MATCH_REFERENCE_PLUS_FIELD, (match, path, _, field) => {
-          const elem = this.resolveRef(path);
-          if (elem !== undefined) {
-            if (field !== undefined) {
-              return elem.getFieldValue(field);
-            }
-            // Field name not specified, return the value of the form field.
-            return elem.getValue();
-          }
-          // Form field not found.
-          return '';
-        });
+    return formatReferencePlusField(formatIndex(label));
+  }
+
+  /**
+   * Replace each instance of {@linkplain $index} with the index of this field.
+   * @param  {String} string The string to replace the occurences in.
+   * @return {String}        The string with all the occurences replaced.
+   */
+  formatIndex(string) {
+    return string.replace(Field.MATCH_INDEX, this.index + 1);
+  }
+
+  /**
+   * Replace all field references with the values of the references.
+   * See {@link #MATCH_REFERENCE_PLUS_FIELD} to see what kind of references are allowed.
+   * @param  {String} string The string to replace the occurences in.
+   * @return {String}        The string with all the occurences replaced.
+   */
+  formatReferencePlusField(string) {
+    return string.replace(Field.MATCH_REFERENCE_PLUS_FIELD, (match, path, _, field) => {
+      const elem = this.resolveRef(path);
+      if (elem !== undefined) {
+        if (field !== undefined) {
+          return elem.getFieldValue(field);
+        }
+        // Field name not specified, return the value of the form field.
+        return elem.getValue();
+      }
+      // Form field not found.
+      return '';
+    });
   }
 
   /**


### PR DESCRIPTION
The field label formatter is not that readable and contains undocumented regex patterns. This pull request splits up the label formatting things to multiple functions that have better documentations and moves the regex patterns to static variables with explanations and examples in the comments.