### PR TITLE
Add getter that recursively gets the full path to the field

### DIFF
--- a/src/resources/elements/abstract/field.js
+++ b/src/resources/elements/abstract/field.js
@@ -119,6 +119,15 @@ export class Field {
   isEmpty() {
     return false;
   }
+  /**
+   * Recursively get an unique identifier for this field.
+   */
+  get path() {
+    if (!this.parent) {
+      return this.id;
+    }
+    return `${this.parent.path}.${this.id}`;
+  }
 
   get display() {
     return this.shouldDisplay();


### PR DESCRIPTION
This pull request adds a `path` getter to fields. The value of `path` can be used for uniquely identifying fields.