### PR TITLE
Fix Optionfield setValue() and remove unused selectionChanged()

### DIFF
--- a/src/resources/elements/optionfield.js
+++ b/src/resources/elements/optionfield.js
@@ -210,17 +210,9 @@ export class Optionfield extends Field {
           choice.selected = false;
         }
       }
-    }
-  }
 
-  /**
-   * Call {@link #setValue()} and {@link #onChange()}
-   * @param {String|String[]} value The new choice or choices depending on the
-   *                                format of this field.
-   */
-  selectionChanged(value) {
-    this.setValue(value);
-    this.onChange();
+      this.selectedChoice = value;
+    }
   }
 
   /**


### PR DESCRIPTION
This pull request fixes `Optionfield.setValue()` for dropdowns by making it set the `selectedChoice` variable. This also removes the unused `selectionChanged()` method which was unintentionally not removed earlier.