### PR TITLE
Cache setValue call in Lazylinkfield if child is not available

### DIFF
--- a/src/resources/elements/lazylinkfield.js
+++ b/src/resources/elements/lazylinkfield.js
@@ -10,6 +10,7 @@ export class LazyLinkfield extends Field {
   target = '#';
   overrides = {};
   child = undefined;
+  cachedValue = undefined;
 
   /** @inheritdoc */
   init(id = '', args = {}) {
@@ -54,6 +55,10 @@ export class LazyLinkfield extends Field {
       } else {
         target[lastFieldPathEntry] = value;
       }
+    }
+    if (this.cachedValue) {
+      this.child.setValue(this.cachedValue);
+      this.cachedValue = undefined;
     }
   }
 
@@ -103,6 +108,10 @@ export class LazyLinkfield extends Field {
    */
   setValue(value) {
     if (!this.child) {
+      // Caching values helps when using setValue() in a big form. By caching
+      // the values, we won't lose setValue data due to dependencies of this
+      // field not getting their value set before this field.
+      this.cachedValue = value;
       return;
     }
     this.child.setValue(value);

--- a/src/resources/elements/lazylinkfield.js
+++ b/src/resources/elements/lazylinkfield.js
@@ -56,6 +56,7 @@ export class LazyLinkfield extends Field {
         target[lastFieldPathEntry] = value;
       }
     }
+    // Use cached value if it has been set.
     if (this.cachedValue) {
       this.child.setValue(this.cachedValue);
       this.cachedValue = undefined;


### PR DESCRIPTION
This pull request makes `Lazylinkfield.setValue()` calls store the given value into a temporary variable if the child of the `Lazylinkfield` doesn't exist yet. This fixes many problems when doing larger scoped `setValue()` calls (such as loading the cache from `localStorage` or otherwise importing a spec)