### PR TITLE
Change showType into typeKey

### DIFF
--- a/src/resources/elements/typefield.js
+++ b/src/resources/elements/typefield.js
@@ -197,19 +197,32 @@ export class Typefield extends Field {
     return value;
   }
 
+  /**
+   * Set the value of this field. This reverses anything that{@link #getValue()}
+   * does.
+   * @param {Object} value The value to set to this field.
+   */
   setValue(value) {
+    // If the key is available in the given value object, get the key from there
+    // and delete the field (from the value object) it was stored in.
     if (this.keyKey && value.hasOwnProperty(this.keyKey)) {
       this.key = value[this.keyKey];
       delete value[this.keyKey];
     }
+    // Do the same for the type
     if (this.typeKey && value.hasOwnProperty(this.typeKey)) {
       this.setType(value[this.typeKey]);
       delete value[this.typeKey];
     }
-    if (!this.valueKey && typeof value === 'object' && !Array.isArray(value)) {
-      this.child.setValue(value);
+    // Try to reverse getValue() in a reliable way.
+    // Currently this looks at whether or not valueKey is set and also the type
+    // of the object found with valueKey.
+    const valueInValueKey = value[this.valueKey || 'value'];
+    const valueIsNotObject = typeof valueInValueKey === 'object' && !Array.isArray(valueInValueKey);
+    if (this.valueKey || ((this.typeKey || this.keyKey) && valueIsNotObject)) {
+      this.child.setValue(valueInValueKey);
     } else {
-      this.child.setValue(value[this.valueKey || 'value']);
+      this.child.setValue(value);
     }
   }
 

--- a/src/resources/elements/typefield.js
+++ b/src/resources/elements/typefield.js
@@ -35,12 +35,13 @@ export class Typefield extends Field {
    */
   key = '';
   /**
-   * The placeholder for the key form field.
+   * The UI placeholder for the key form field.
    * @type {String}
    */
   keyPlaceholder = '';
   /**
-   * The key where to put the type of this field.
+   * The key where to put the type of this field in the output of this field.
+   * The default is {@linkplain x-oad-type} so it won't break the OpenAPI spec.
    * @type {String}
    */
   typeKey = 'x-oad-type';
@@ -88,10 +89,27 @@ export class Typefield extends Field {
     }
   }
 
-  /** @inheritdoc */
+  /**
+   * @inheritdoc
+   * @param {String} [args.valueKey] The key where to put the value of the child
+   *                                 field to in the output of this field.
+   * @param {String} [args.typeKey]  The key where to put the type of this field
+   *                                 in the output of this field.
+   * @param {String} [args.keyKey]   The key where to put the key of this field
+   *                                 ({@link #key}) in the output of this field.
+   * @param {Object} [args.types]    The schemas for the available types.
+   * @param {Boolean} [args.copyValue] Whether or not to copy the value over to
+   *                                   the new child when switching types.
+   * @param {Boolean} [args.collapsed] Whether or not to make the UI field be
+   *                                   collapsed by default.
+   * @param {String} [args.keyPlaceholder] The UI placeholder for the key form field.
+   * @param {String} [args.selectedType]   The type that should be selected by
+   *                                       default.
+   */
   init(id = '', args = {}) {
     args = Object.assign({
       valueKey: '',
+      // Set default typeKey to something that doesn't break the OpenAPI spec.
       typeKey: 'x-oad-type',
       keyKey: '',
       keyPlaceholder: 'Object key...',

--- a/src/schemas/security.js
+++ b/src/schemas/security.js
@@ -36,6 +36,7 @@ const securityDefinitions = {
     'type': 'selectable',
     'defaultType': 'basic',
     'keyKey': 'key',
+    'typeKey': 'type',
     'types': {
       'basic': {
         'label': '',
@@ -116,6 +117,7 @@ const securityDefinitions = {
 export const security = {
   'type': 'object',
   'label': 'Security',
+  'showValueInParent': false,
   'children': {
     definitions: securityDefinitions,
     requirements: securityRequirements


### PR DESCRIPTION
This pull request changes the `showType` variable in `Typefield`s into `typeKey` to allow customizing the key where the type is stored. The default key is also changed from `type` to `x-oad-type`.