### PR TITLE
Improve path resolving

### DIFF
--- a/src/resources/elements/abstract/parentfield.js
+++ b/src/resources/elements/abstract/parentfield.js
@@ -75,9 +75,9 @@ export class Parentfield extends Field {
 
   /** @inheritdoc */
   resolvePath(path) {
-    const superResolv = super.resolvePath(path);
-    if (superResolv) {
-      return superResolv;
+    const parentResolveResult = super.resolvePath(path);
+    if (parentResolveResult) {
+      return parentResolveResult;
     }
 
     const elem = this._children[path[0]];

--- a/src/resources/elements/arrayfield.js
+++ b/src/resources/elements/arrayfield.js
@@ -202,9 +202,9 @@ export class Arrayfield extends Parentfield {
   }
 
   resolvePath(path) {
-    const superResolv = super.resolvePath(path);
-    if (superResolv) {
-      return superResolv;
+    const parentResolveResult = super.resolvePath(path);
+    if (parentResolveResult) {
+      return parentResolveResult;
     }
 
     if (this.format === 'map') {

--- a/src/resources/elements/arrayfield.js
+++ b/src/resources/elements/arrayfield.js
@@ -214,14 +214,14 @@ export class Arrayfield extends Parentfield {
         const [, fieldName, value] = match;
         for (const child of this._children) {
           if (child.getValue()[fieldName] === value) {
-            return child;
+            return child.resolvePath(path.splice(1));
           }
         }
       }
     }
 
     if (path[0] === ':item') {
-      return this.item;
+      return this.item.resolvePath(path.splice(1));
     }
     return undefined;
   }

--- a/src/resources/elements/arrayfield.js
+++ b/src/resources/elements/arrayfield.js
@@ -207,6 +207,19 @@ export class Arrayfield extends Parentfield {
       return superResolv;
     }
 
+    if (this.format === 'map') {
+      // Matches `fieldName(expectedValue)`
+      const match = (/([a-zA-Z0-9]+)\((.+?)\)/g).exec(path[0]);
+      if (match) {
+        const [, fieldName, value] = match;
+        for (const child of this._children) {
+          if (child.getValue()[fieldName] === value) {
+            return child;
+          }
+        }
+      }
+    }
+
     if (path[0] === ':item') {
       return this.item;
     }

--- a/src/resources/elements/arrayfield.js
+++ b/src/resources/elements/arrayfield.js
@@ -209,11 +209,18 @@ export class Arrayfield extends Parentfield {
 
     if (this.format === 'map') {
       // Matches `fieldName(expectedValue)`
+      // First capture group: Field name
+      // Second capture group: Expected value of given field.
       const match = (/([a-zA-Z0-9]+)\((.+?)\)/g).exec(path[0]);
       if (match) {
-        const [, fieldName, value] = match;
+        // Match found, loop through children to find a child that has the
+        // expected value in the given field.
+
+        // Result unpacking: first element is the whole match and the remaining
+        // elements are capture group results.
+        const [, fieldName, expectedValue] = match;
         for (const child of this._children) {
-          if (child.getValue()[fieldName] === value) {
+          if (child.getValue()[fieldName] === expectedValue) {
             return child.resolvePath(path.splice(1));
           }
         }

--- a/src/resources/elements/lazylinkfield.js
+++ b/src/resources/elements/lazylinkfield.js
@@ -126,6 +126,8 @@ export class LazyLinkfield extends Field {
       return parentResolveResult;
     }
 
+    // If the child exists and the next path piece to be resolved targets the
+    // child, continue recursing from the child.
     if (this.child && path[0] === ':child') {
       return this.child.resolvePath(path.splice(1));
     }

--- a/src/resources/elements/lazylinkfield.js
+++ b/src/resources/elements/lazylinkfield.js
@@ -121,9 +121,9 @@ export class LazyLinkfield extends Field {
   }
 
   resolvePath(path) {
-    const superResolv = super.resolvePath(path);
-    if (superResolv) {
-      return superResolv;
+    const parentResolveResult = super.resolvePath(path);
+    if (parentResolveResult) {
+      return parentResolveResult;
     }
 
     if (this.child && path[0] === ':child') {

--- a/src/resources/elements/lazylinkfield.js
+++ b/src/resources/elements/lazylinkfield.js
@@ -119,4 +119,16 @@ export class LazyLinkfield extends Field {
   getValue() {
     return this.child ? this.child.getValue() : undefined;
   }
+
+  resolvePath(path) {
+    const superResolv = super.resolvePath(path);
+    if (superResolv) {
+      return superResolv;
+    }
+
+    if (this.child && path[0] === ':child') {
+      return this.child.resolvePath(path.splice(1));
+    }
+    return undefined;
+  }
 }

--- a/src/resources/elements/linkfield.js
+++ b/src/resources/elements/linkfield.js
@@ -51,6 +51,8 @@ export class Linkfield extends Field {
       return parentResolveResult;
     }
 
+    // If the target exists and the next path piece to be resolved targets the
+    // target, continue recursing from the target.
     if (path[0] === ':target') {
       const target = this.resolveTarget();
       if (target) {

--- a/src/resources/elements/linkfield.js
+++ b/src/resources/elements/linkfield.js
@@ -46,9 +46,9 @@ export class Linkfield extends Field {
   }
 
   resolvePath(path) {
-    const superResolv = super.resolvePath(path);
-    if (superResolv) {
-      return superResolv;
+    const parentResolveResult = super.resolvePath(path);
+    if (parentResolveResult) {
+      return parentResolveResult;
     }
 
     if (path[0] === ':target') {

--- a/src/resources/elements/linkfield.js
+++ b/src/resources/elements/linkfield.js
@@ -45,6 +45,21 @@ export class Linkfield extends Field {
     return field;
   }
 
+  resolvePath(path) {
+    const superResolv = super.resolvePath(path);
+    if (superResolv) {
+      return superResolv;
+    }
+
+    if (path[0] === ':target') {
+      const target = this.resolveTarget();
+      if (target) {
+        return target.resolvePath(path.splice(1));
+      }
+    }
+    return undefined;
+  }
+
   /**
    * Set the value of the target field.
    *

--- a/src/resources/elements/objectfield.js
+++ b/src/resources/elements/objectfield.js
@@ -144,9 +144,9 @@ export class Objectfield extends Parentfield {
   }
 
   resolvePath(path) {
-    const superResolv = super.resolvePath(path);
-    if (superResolv) {
-      return superResolv;
+    const parentResolveResult = super.resolvePath(path);
+    if (parentResolveResult) {
+      return parentResolveResult;
     }
 
     if (this.hasLegend) {

--- a/src/resources/elements/typefield.js
+++ b/src/resources/elements/typefield.js
@@ -225,6 +225,8 @@ export class Typefield extends Field {
       return parentResolveResult;
     }
 
+    // If the child exists and the next path piece to be resolved targets the
+    // child, continue recursing from the child.
     if (this.child && path[0] === ':child') {
       return this.child.resolvePath(path.splice(1));
     }

--- a/src/resources/elements/typefield.js
+++ b/src/resources/elements/typefield.js
@@ -219,6 +219,18 @@ export class Typefield extends Field {
     return this.selectedType;
   }
 
+  resolvePath(path) {
+    const superResolv = super.resolvePath(path);
+    if (superResolv) {
+      return superResolv;
+    }
+
+    if (this.child && path[0] === ':child') {
+      return this.child.resolvePath(path.splice(1));
+    }
+    return undefined;
+  }
+
   /**
    * Get all the possible type names.
    * @return {String[]} The names of the possible types.

--- a/src/resources/elements/typefield.js
+++ b/src/resources/elements/typefield.js
@@ -220,9 +220,9 @@ export class Typefield extends Field {
   }
 
   resolvePath(path) {
-    const superResolv = super.resolvePath(path);
-    if (superResolv) {
-      return superResolv;
+    const parentResolveResult = super.resolvePath(path);
+    if (parentResolveResult) {
+      return parentResolveResult;
     }
 
     if (this.child && path[0] === ':child') {


### PR DESCRIPTION
This pull request improves the internal path resolving in many classes:
1. Resolving array children can be done by finding the child with a specific field value.
2. Resolving the active child of Typefields and LazyLinkfields is now possible.
3. Resolving the target of Linkfields is now possible.