### PR TITLE
Allow overriding new item button text in Arrayfields

### DIFF
--- a/src/resources/elements/arrayfield.html
+++ b/src/resources/elements/arrayfield.html
@@ -8,7 +8,7 @@
     </h3>
     <div class="controls" if.bind="!collapsed">
       <button class="new-item" click.delegate="addChild()">
-        New ${item.label}
+        ${newItemText ? newItemText : "New " + item.label}
       </button>
     </div>
     <div class="items" if.bind="!collapsed">

--- a/src/resources/elements/arrayfield.js
+++ b/src/resources/elements/arrayfield.js
@@ -13,6 +13,12 @@ export class Arrayfield extends Parentfield {
    */
   item;
   /**
+   * The text that is displayed in the new item -button rather than the label of
+   * the child.
+   * @type {String}
+   */
+  newItemText;
+  /**
    * The field that is used as the key if {@link #format} is {@linkplain map}
    * @type {String}
    */
@@ -40,20 +46,24 @@ export class Arrayfield extends Parentfield {
 
   /**
    * @inheritdoc
-   * @param {Field}   [args.item]       The base object that is cloned to create
-   *                                    new children.
-   * @param {String}  [args.keyField]   The field that is used as the key if
-   *                                    {@link #format} is {@linkplain map}
-   * @param {String}  [args.valueField] The field that is used as the value if
-   *                                    {@link #format} is {@linkplain map}.
-   *                                    This field is optional. By default, the
-   *                                    whole value will be used as-is.
-   * @param {Boolean} [args.collapsed]  Whether or not the UI element should be
-   *                                    collapsed.
+   * @param {Field}   [args.item]        The base object that is cloned to create
+   *                                     new children.
+   * @param {String}  [args.newItemText] The text that is displayed in the new
+   *                                     item -button rather than the label of
+   *                                     the child.
+   * @param {String}  [args.keyField]    The field that is used as the key if
+   *                                     {@link #format} is {@linkplain map}
+   * @param {String}  [args.valueField]  The field that is used as the value if
+   *                                     {@link #format} is {@linkplain map}.
+   *                                     This field is optional. By default, the
+   *                                     whole value will be used as-is.
+   * @param {Boolean} [args.collapsed]   Whether or not the UI element should be
+   *                                     collapsed.
    */
   init(id = '', args = {}) {
     args = Object.assign({
       format: 'array',
+      newItemText: undefined,
       keyField: '_key',
       valueField: undefined,
       addIndexToChildLabel: true,
@@ -61,6 +71,7 @@ export class Arrayfield extends Parentfield {
       collapsed: false
     }, args);
     this.item = args.item;
+    this.newItemText = args.newItemText;
     this.keyField = args.keyField;
     this.valueField = args.valueField;
     this.addIndexToChildLabel = args.addIndexToChildLabel;


### PR DESCRIPTION
This pull request adds a new field called `newItemText` to `Arrayfield`s that can be used to override the text displayed in the new child adding button. If `newItemText` is not set, the new child button still defaults to `New <child label>`