### PR TITLE
Implement isEmpty() for Optionfield

### DIFF
--- a/src/resources/elements/abstract/field.js
+++ b/src/resources/elements/abstract/field.js
@@ -136,7 +136,7 @@ export class Field {
    * implementations should override this.
    */
   isEmpty() {
-    return false;
+    return true;
   }
   /**
    * Recursively get an unique identifier for this field.

--- a/src/resources/elements/optionfield.js
+++ b/src/resources/elements/optionfield.js
@@ -89,6 +89,10 @@ export class Optionfield extends Field {
     return super.init(id, args);
   }
 
+  /**
+   * Check if this Optionfield is empty. An Optionfield is empty either if the
+   * value is false or the value array (checkbox-formatted field) is empty.
+   */
   isEmpty() {
     const value = this.getValue();
     return !value || (Array.isArray(value) && value.length === 0);

--- a/src/resources/elements/optionfield.js
+++ b/src/resources/elements/optionfield.js
@@ -89,6 +89,11 @@ export class Optionfield extends Field {
     return super.init(id, args);
   }
 
+  isEmpty() {
+    const value = this.getValue();
+    return !value || (Array.isArray(value) && value.length === 0);
+  }
+
   created() {
     const ds = this.dataSources;
     this.dataSources = [];


### PR DESCRIPTION
Fixes #154 

This pull request adds an `isEmpty()` implementation for `Optionfield` and changes the default value of `isEmpty()` to `true`.