### PR TITLE
Add gh-deployer instruction file

### DIFF
--- a/.gh-deployer.yaml
+++ b/.gh-deployer.yaml
@@ -1,0 +1,6 @@
+shell: /bin/bash
+shell-args: [ "-c" ]
+
+commands:
+- npm install
+- au build


### PR DESCRIPTION
Now that we have [openapi.design](https://openapi.design) and a VPS dedicated for that, we can set up an automated system to deploy development previews. This pull request adds a [gh-deployer](https://github.com/tulir/gh-deployer) config to do that.

In addition to this file, we'll need to set up Github webhooks and the dev.openapi.design subdomain.